### PR TITLE
Fixes //-style patterns

### DIFF
--- a/tasks/copy-part-of-file.js
+++ b/tasks/copy-part-of-file.js
@@ -98,7 +98,7 @@ var insertScriptsIntoDestinationFile = function(destinationContent, scriptsStr, 
     var matcher = getRegex(start.source + '[^]*' + end.source);
     //console.log("Matcher: " + matcher);
     //console.log("TEST: ", matcher.test(destinationContent));
-    var replacer = start.source + '\n' + scriptsStr + '\n' + end.source;
+    var replacer = startPattern + '\n' + scriptsStr + '\n' + endPattern;
     var replaced = destinationContent.replace(matcher, replacer);
     //console.log("Replaced: ", replaced);
     return replaced;


### PR DESCRIPTION
Hello,
I am using copy-part-of-file to dynamically change an array in a javascript file.

I used the following Gruntfile-config:

```javascript
'copy-part-of-file': {
    target: {
        options: {
            sourceFileStartPattern: '// Start Pattern',
            sourceFileEndPattern: '// End Pattern',
            destinationFileStartPattern: '// Start Pattern',
            destinationFileEndPattern: '// End Pattern'
        },
        files: {
            'js/main.js': ['tmp/p_tmp.js']
        }
    }
}
```

However, when i run this task these comments end up destroyed in the file:

```javascript
\/\/ Start Pattern
...
\/\/ End Pattern
```

This PR fixes this by not using the source-property of the RegExp being created. It uses the original Pattern instead.