### PR TITLE
add support for javascript style comments

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,6 +52,28 @@ module.exports = function(grunt) {
             files: {
                 'test/fixtures/simple-destination.html': ['test/fixtures/simple-source.html']
             }
+        },
+        line_comment_replace_scripts: {
+            options: {
+                sourceFileStartPattern: '// Start Source',
+                sourceFileEndPattern: '// End Source',
+                destinationFileStartPattern: '// Start Destination',
+                destinationFileEndPattern: '// End Destination'
+            },
+            files: {
+                'test/fixtures/javascript-line-comment-destination.js': ['test/fixtures/javascript-line-comment-source.js']
+            }
+        },
+        block_comment_replace_scripts: {
+            options: {
+                sourceFileStartPattern: '/* Start Source */',
+                sourceFileEndPattern: '/* End Source */',
+                destinationFileStartPattern: '/* Start Destination */',
+                destinationFileEndPattern: '/* End Destination */'
+            },
+            files: {
+                'test/fixtures/javascript-block-comment-destination.js': ['test/fixtures/javascript-block-comment-source.js']
+            }
         }
     },
 

--- a/tasks/copy-part-of-file.js
+++ b/tasks/copy-part-of-file.js
@@ -98,7 +98,7 @@ var insertScriptsIntoDestinationFile = function(destinationContent, scriptsStr, 
     var matcher = getRegex(start.source + '[^]*' + end.source);
     //console.log("Matcher: " + matcher);
     //console.log("TEST: ", matcher.test(destinationContent));
-    var replacer = start.source + '\n' + scriptsStr + '\n' + end.source;
+    var replacer = startPattern + '\n' + scriptsStr + '\n' + endPattern;
     var replaced = destinationContent.replace(matcher, replacer);
     //console.log("Replaced: ", replaced);
     return replaced;

--- a/test/copy_index_scripts_test.js
+++ b/test/copy_index_scripts_test.js
@@ -27,5 +27,25 @@ exports.copy = {
         test.equal(actual, expected, 'the destination file does not match what was expected');
 
         test.done();
+    },
+    line_comment_replace_scripts: function(test) {
+        test.expect(1);
+
+        var actual = grunt.file.read('test/fixtures/javascript-line-comment-destination.js');
+        var expected = grunt.file.read('test/expected/javascript-line-comment-expected.js');
+        //console.log("test1", actual, expected);
+        test.equal(actual, expected, 'the destination file does not match what was expected');
+
+        test.done();
+    },
+    block_comment_replace_scripts: function(test) {
+        test.expect(1);
+
+        var actual = grunt.file.read('test/fixtures/javascript-block-comment-destination.js');
+        var expected = grunt.file.read('test/expected/javascript-block-comment-expected.js');
+        //console.log("test1", actual, expected);
+        test.equal(actual, expected, 'the destination file does not match what was expected');
+
+        test.done();
     }
 };

--- a/test/expected/javascript-block-comment-expected.js
+++ b/test/expected/javascript-block-comment-expected.js
@@ -1,0 +1,5 @@
+function aTest() {
+/* Start Destination */
+var a = ['1', '2', '3'];
+/* End Destination */
+}

--- a/test/expected/javascript-line-comment-expected.js
+++ b/test/expected/javascript-line-comment-expected.js
@@ -1,0 +1,5 @@
+function aTest() {
+// Start Destination
+var a = ['1', '2', '3'];
+// End Destination
+}

--- a/test/fixtures/javascript-block-comment-destination.js
+++ b/test/fixtures/javascript-block-comment-destination.js
@@ -1,0 +1,5 @@
+function aTest() {
+/* Start Destination */
+var a = ['1', '2', '3'];
+/* End Destination */
+}

--- a/test/fixtures/javascript-block-comment-source.js
+++ b/test/fixtures/javascript-block-comment-source.js
@@ -1,0 +1,3 @@
+/* Start Source */
+var a = ['1', '2', '3'];
+/* End Source */

--- a/test/fixtures/javascript-line-comment-destination.js
+++ b/test/fixtures/javascript-line-comment-destination.js
@@ -1,0 +1,5 @@
+function aTest() {
+// Start Destination
+var a = ['1', '2', '3'];
+// End Destination
+}

--- a/test/fixtures/javascript-line-comment-source.js
+++ b/test/fixtures/javascript-line-comment-source.js
@@ -1,0 +1,3 @@
+// Start Source
+var a = ['1', '2', '3'];
+// End Source


### PR DESCRIPTION
This PR fixes a bug if one wants to use grunt-copy-part-of-file in javascript files with javascript-style comments as patterns.