### PR TITLE
Added transformation option and a small bug fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,6 +53,18 @@ module.exports = function(grunt) {
                 'test/fixtures/simple-destination.html': ['test/fixtures/simple-source.html']
             }
         },
+        line_transformation_replace_scripts: {
+            options: {
+                sourceFileStartPattern: '// Start Source',
+                sourceFileEndPattern: '// End Source',
+                destinationFileStartPattern: '// Start Destination',
+                destinationFileEndPattern: '// End Destination',
+                lineTransformer: (line) => line.includes("foo") ? line.replace("foo", "baz") : line
+            },
+            files: {
+                'test/fixtures/simple-transform-destination.js': ['test/fixtures/simple-transform-source.js']
+            }
+        },
         line_comment_replace_scripts: {
             options: {
                 sourceFileStartPattern: '// Start Source',

--- a/test/copy_index_scripts_test.js
+++ b/test/copy_index_scripts_test.js
@@ -28,6 +28,16 @@ exports.copy = {
 
         test.done();
     },
+    line_transformation_replace_scripts: function(test) {
+        test.expect(1);
+
+        var actual = grunt.file.read('test/fixtures/simple-transform-destination.js');
+        var expected = grunt.file.read('test/expected/simple-transform-expected.js');
+
+        test.equal(actual, expected, 'the destination file does not match what was expected');
+
+        test.done();
+    },
     line_comment_replace_scripts: function(test) {
         test.expect(1);
 

--- a/test/expected/simple-transform-expected.js
+++ b/test/expected/simple-transform-expected.js
@@ -1,0 +1,6 @@
+function aTest() {
+// Start Destination
+var baz = ['1', '2', '3'];
+var zoo = ['4', '5', '6'];
+// End Destination
+}

--- a/test/fixtures/simple-transform-destination.js
+++ b/test/fixtures/simple-transform-destination.js
@@ -1,0 +1,6 @@
+function aTest() {
+// Start Destination
+var foo = ['1', '2', '3'];
+var zoo = ['4', '5', '6'];
+// End Destination
+}

--- a/test/fixtures/simple-transform-source.js
+++ b/test/fixtures/simple-transform-source.js
@@ -1,0 +1,4 @@
+// Start Source
+var foo = ['1', '2', '3'];
+var zoo = ['4', '5', '6'];
+// End Source


### PR DESCRIPTION
I have added a lineTransformer:[Function] sort of a mapper that would take in a line and have the client the ability to provide any kind of replacement. Very useful in mapping from different file types to different, like from .java to .js or .cs to .js etc. Also, fixed a bug that was causing the tests to break. When join the scripts we were joining like scripts.join(\n) and weren't taking care of the \r so I added \r\n to join. All tests passing. 